### PR TITLE
Add ~/.local/bin to path and export $NOTES_DIR variable in fish shell

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,13 +17,19 @@ mkdir -p ~/.local/bin
 ln -sfnv "$PWD/tdo.sh" ~/.local/bin/tdo
 
 if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-    echo 'export PATH="$HOME/.local/bin:$PATH"' >>"$exports_file"
+    case "$SHELL" in
+    */fish) fish -c "fish_add_path $HOME/.local/bin" ;;
+    *) echo 'export PATH="$HOME/.local/bin:$PATH"' >>"$exports_file" ;;
+    esac
 fi
 
 if [ ! -d "$NOTES_DIR" ]; then
     NOTES_DIR="$HOME/Projects/notes"
     mkdir -p "$NOTES_DIR"
-    echo "export NOTES_DIR=$NOTES_DIR" >>"$exports_file"
+    case "$SHELL" in
+    */fish) fish -c "set -Ux NOTES_DIR $NOTES_DIR" ;;
+    *) echo "export NOTES_DIR=$NOTES_DIR" >>"$exports_file" ;;
+    esac
 fi
 
 cp -irv templates/ "$NOTES_DIR/"


### PR DESCRIPTION
## What

What does this pull request accomplish?

- [x] Add `~/.local/bin` directory to path in fish
- [x] Export `$NOTES_DIR` env variable in fish

## How

What code changes were made to accomplish it?

- Use `fish_add_path` to modify path
- Use `set -Ux` to export env variable

## Why

- [x] I want to fix the issue #3 

# Checklist

- [X] I have performed a self-review of my own code

