### PR TITLE
Remove slash from templates dir in the cp command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ if [ ! -d "$NOTES_DIR" ]; then
     echo "export NOTES_DIR=$NOTES_DIR" >>"$exports_file"
 fi
 
-cp -irv templates/ "$NOTES_DIR/"
+cp -irv templates "$NOTES_DIR/"
 
 echo "tdo setup completed successfully!"
 echo "Please make sure to reload your shell configuration using 'source $exports_file'."


### PR DESCRIPTION
## What

What does this pull request accomplish?

- [x] Remove the slash from `templates/` in `cp -irv templates/ "$NOTES_DIR/"`


## Why

- [x] I want to fix the issue of the templates directory not being copied into the `$NOTES_DIR` directory. Currently, the template files are copied into `$NOTES_DIR` without the templates directory. That is, the file structure is

```
├── entry.md
└── note.md
└── todo.md
```

Instead of

```
└── templates
    ├── entry.md
    └── note.md
    └── todo.md
```


# Checklist

- [x] I have performed a self-review of my own code
