### PR TITLE
Check if NOTES_DIR env var has been added already in fish

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,9 @@ install_shell() {
     if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
         echo 'export PATH="$HOME/.local/bin:$PATH"' >>"$exports_file"
     fi
-    echo "export NOTES_DIR=$NOTES_DIR" >>"$exports_file"
+    if ! printenv NOTES_DIR > /dev/null; then
+        echo "export NOTES_DIR=$NOTES_DIR" >>"$exports_file"
+    fi
 }
 
 if [ -z "$EDITOR" ]; then

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,9 @@ install_fish() {
     if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
         fish -c "fish_add_path $HOME/.local/bin"
     fi
-    fish -c "set -Ux NOTES_DIR $NOTES_DIR"
+    if ! printenv NOTES_DIR > /dev/null; then
+        fish -c "set -Ux NOTES_DIR $NOTES_DIR"
+    fi
 }
 
 install_shell() {


### PR DESCRIPTION
## What

What does this pull request accomplish?

- [x] Check if `$NOTES_DIR` is already an env. variable (not just a directory)

## How

What code changes were made to accomplish it?

- Using `! printenv NOTES_DIR > /dev/null` for that

## Why

- If I have added $NOTES_DIR manually already, then the current script would add it again.

