### PR TITLE
mkdir if file_path does not exist

### DIFF
--- a/tdo.sh
+++ b/tdo.sh
@@ -88,8 +88,8 @@ create_file() {
     file_path="$1"
     template_path="$2"
 
-    mkdir -p "$(dirname "$file_path")"
     if [ ! -f "$file_path" ]; then
+        mkdir -p "$(dirname "$file_path")"
         [ -f "$template_path" ] && cp "$template_path" "$file_path"
     fi
 }


### PR DESCRIPTION
## What

What does this pull request accomplish?

- [x] Minor modification when creating a file

## How

What code changes were made to accomplish it?

- Modify the `create_file` function to `mkdir` only when `file_path` does not exits.

## Why

- [x] Although it is not costly to do so, there is no need to `mkdir` every time when using this function.


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
