### PR TITLE
Add env variables and tdorc config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ tdo is a opinionated, command line based note-taking system. [Demo video](https:
 
 ## ⚡ Setup
 
-### ⚙️ Requirements
+### 📋 Requirements
 
 - ripgrep, fzf
 - bat (optional, for syntax highlighting in search)
@@ -145,11 +145,10 @@ If you use Neovim, I highly recommend using [tdo.nvim](https://github.com/2kabhi
     └── note.md
     └── todo.md
 ```
-## Configuration
+
+### ⚙️ Configuration
 
 You can configure `tdo` by either defining environment variables or via a `$HOME/.config/tdorc` file.
-
-> configs defined in `tdorc` will override corresponding environment variables
 
 - `ADD_ENTRY_TIMESTAMP` `[boolean]`: Whether to add a time stamp when using `tdo entry` or `tdo e`.
 - `ADD_NEW_NOTE_TIMESTAMP` `[boolean]`: Whether to add a time stamp when creating new notes with `tdo <note_title>`.
@@ -157,7 +156,7 @@ You can configure `tdo` by either defining environment variables or via a `$HOME
 - `ENTRY_TIMESTAMP_FORMAT` `[string]`: can be any bash string such as a date format expression. It is ignored if `ADD_ENTRY_TIMESTAMP` is set to `false`.
 - `NOTE_TIMESTAMP_FORMAT`(`[string]`: can be any bash string such as a date format expression. It is ignored if `ADD_NEW_NOTE_TIMESTAMP` is set to `false`.
 
-### Default Configs
+#### Default Configs
 
 ```bash
 ADD_ENTRY_TIMESTAMP=true
@@ -167,6 +166,9 @@ FILE_NAME_AS_TITLE=false
 ENTRY_TIMESTAMP_FORMAT="## %a, %I:%M %p"
 # Reads ## Fri. Apr 06, 2024 - 06:48 PM
 NOTE_TIMESTAMP_FORMAT="## %a. %b %d, %Y - %I:%M %p"
+```
+
+> configs defined in `tdorc` will override corresponding environment variables
 
 ## 🏗️ What's Next
 

--- a/README.md
+++ b/README.md
@@ -147,31 +147,26 @@ If you use Neovim, I highly recommend using [tdo.nvim](https://github.com/2kabhi
 ```
 ## Configuration
 
-You can further configure `tdo` by either defining environment variables or via a `tdorc` file.
+You can configure `tdo` by either defining environment variables or via a `$HOME/.config/tdorc` file.
 
-### Using environment variables
+> configs defined in `tdorc` will override corresponding environment variables
 
-You can set the following (optional) environment variables:
+- `ADD_ENTRY_TIMESTAMP` `[boolean]`: Whether to add a time stamp when using `tdo entry` or `tdo e`.
+- `ADD_NEW_NOTE_TIMESTAMP` `[boolean]`: Whether to add a time stamp when creating new notes with `tdo <note_title>`.
+- `FILE_NAME_AS_TITLE` `[boolean]`: Whether to add the file name as title when creating new notes with `tdo <note_title>`. If `true`, then it adds `<note_title>` as a markdown title in the first line of the new note.
+- `ENTRY_TIMESTAMP_FORMAT` `[string]`: can be any bash string such as a date format expression. It is ignored if `ADD_ENTRY_TIMESTAMP` is set to `false`.
+- `NOTE_TIMESTAMP_FORMAT`(`[string]`: can be any bash string such as a date format expression. It is ignored if `ADD_NEW_NOTE_TIMESTAMP` is set to `false`.
 
-- `ADD_ENTRY_TIMESTAMP` (`[boolean]` defaults to `true`): Whether to add a time stamp when using `tdo entry` or `tdo e`.
-- `ADD_NEWNOTE_TIMESTAMP` (`[boolean]` defaults to `false`): Whether to add a time stamp when creating new notes with `tdo <note_title>`.
-- `FILE_NAME_AS_TITLE` (`[boolean]` defaults to `false`): Whether to add the file name as title when creating new notes with `tdo <note_title>`. If `true`, then it adds `<note_title>` as a markdown title in the first line of the new note.
-- `ENTRY_TIMESTAMP_FORMAT` (`[string]` defaults to `"## %a, %I:%M %p"` or `"## Mon, 12:00 PM"`): can be any bash string such as a date format expression. It is ignored if `ADD_ENTRY_TIMESTAMP` is set to `false`.
-- `NOTE_TIMESTAMP_FORMAT`(`[string]` defaults to `"## %a. %b %d, %Y - %I:%M %p"` or `"## Fri. Apr 06, 2024 - 06:48 PM"`): can be any bash string such as a date format expression. It is ignored if `ADD_NEWNOTE_TIMESTAMP` is set to `false`.
-
-### Using a `tdorc` file
-
-Alternatively, it is possible to define the same variables in a `$HOME/.config/tdorc` file following bash syntax. For example:
+### Default Configs
 
 ```bash
-ADD_ENTRY_TIMESTAMP=false
-ADD_NEWNOTE_TIMESTAMP=true
-FILE_NAME_AS_TITLE=true
-ENTRY_TIMESTAMP_FORMAT="## %I:%M %p"
-NOTE_TIMESTAMP_FORMAT="## Created: %a. %b %d, %Y at %I:%M %p"
-```
-
-**Note** that variables defined in `tdorc` will override the corresponding environment variables.
+ADD_ENTRY_TIMESTAMP=true
+ADD_NEW_NOTE_TIMESTAMP=false
+FILE_NAME_AS_TITLE=false
+# Reads ## Mon, 12:00 PM
+ENTRY_TIMESTAMP_FORMAT="## %a, %I:%M %p"
+# Reads ## Fri. Apr 06, 2024 - 06:48 PM
+NOTE_TIMESTAMP_FORMAT="## %a. %b %d, %Y - %I:%M %p"
 
 ## 🏗️ What's Next
 

--- a/README.md
+++ b/README.md
@@ -153,25 +153,25 @@ You can further configure `tdo` by either defining environment variables or via 
 
 You can set the following (optional) environment variables:
 
-- `TIMESTAMP_ENTRY` (`["true"|"false"]` defaults to `"true"`): Whether to add a time stamp when using `tdo entry` or `tdo e`.
-- `TIMESTAMP_NEWNOTE` (`["true"|"false"]` defaults to `"false"`): Whether to add a time stamp when creating new notes with `tdo <note_title>`.
-- `FILE_NAME_AS_TITLE` (`["true"|"false"]` defaults to `"false"`): Whether to add the file name as title when creating new notes with `tdo <note_title>`. If `"true"`, then it adds `<note_title>` as a markdown title to the end of the new note.
-- `ENTRY_TIMESTAMP` (`[string]` defaults to `"## %a, %I:%M %p"`): can be any bash string such as a date format expression. It is ignored if `TIMESTAMP_ENTRY` is set to `"false"`.
-- `NOTE_TIMESTAMP`(`[string]` defaults to `"## %a. %b %d, %Y - %I:%M%p"`): can be any bash string such as a date format expression. It is ignored if `TIMESTAMP_NEWNOTE` is set to `"false"`.
+- `ADD_ENTRY_TIMESTAMP` (`["true"|"false"]` defaults to `"true"`): Whether to add a time stamp when using `tdo entry` or `tdo e`.
+- `ADD_NEWNOTE_TIMESTAMP` (`["true"|"false"]` defaults to `"false"`): Whether to add a time stamp when creating new notes with `tdo <note_title>`.
+- `FILE_NAME_AS_TITLE` (`["true"|"false"]` defaults to `"false"`): Whether to add the file name as title when creating new notes with `tdo <note_title>`. If `"true"`, then it adds `<note_title>` as a markdown title in the first line of the new note.
+- `ENTRY_TIMESTAMP_FORMAT` (`[string]` defaults to `"## %a, %I:%M %p"` or `"## Mon, 12:00 PM"`): can be any bash string such as a date format expression. It is ignored if `ADD_ENTRY_TIMESTAMP` is set to `"false"`.
+- `NOTE_TIMESTAMP_FORMAT`(`[string]` defaults to `"## %a. %b %d, %Y - %I:%M %p"` or `"## Fri. Apr 06, 2024 - 06:48 PM"`): can be any bash string such as a date format expression. It is ignored if `ADD_NEWNOTE_TIMESTAMP` is set to `"false"`.
 
 ### Using a `tdorc` file
 
 Alternatively, it is possible to define the same variables in a `$HOME/.config/tdorc` file following bash syntax. For example:
 
 ```bash
-TIMESTAMP_ENTRY=false
-TIMESTAMP_NEWNOTE=true
+ADD_ENTRY_TIMESTAMP=false
+ADD_NEWNOTE_TIMESTAMP=true
 FILE_NAME_AS_TITLE=true
-ENTRY_TIMESTAMP="## %I:%M %p"
-NOTE_TIMESTAMP="## Created: %a. %b %d, %Y at %I:%M%p"
+ENTRY_TIMESTAMP_FORMAT="## %I:%M %p"
+NOTE_TIMESTAMP_FORMAT="## Created: %a. %b %d, %Y at %I:%M %p"
 ```
 
-**Note** that if any of these variables are set as environment variables, then the `tdorc` will be ignored completely. That is, it is not possible to use both environment variables configuration together with a `tdorc` configuration.
+**Note** that variables defined in `tdorc` will override the corresponding environment variables.
 
 ## 🏗️ What's Next
 

--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ You can further configure `tdo` by either defining environment variables or via 
 
 You can set the following (optional) environment variables:
 
-- `ADD_ENTRY_TIMESTAMP` (`["true"|"false"]` defaults to `"true"`): Whether to add a time stamp when using `tdo entry` or `tdo e`.
-- `ADD_NEWNOTE_TIMESTAMP` (`["true"|"false"]` defaults to `"false"`): Whether to add a time stamp when creating new notes with `tdo <note_title>`.
-- `FILE_NAME_AS_TITLE` (`["true"|"false"]` defaults to `"false"`): Whether to add the file name as title when creating new notes with `tdo <note_title>`. If `"true"`, then it adds `<note_title>` as a markdown title in the first line of the new note.
-- `ENTRY_TIMESTAMP_FORMAT` (`[string]` defaults to `"## %a, %I:%M %p"` or `"## Mon, 12:00 PM"`): can be any bash string such as a date format expression. It is ignored if `ADD_ENTRY_TIMESTAMP` is set to `"false"`.
-- `NOTE_TIMESTAMP_FORMAT`(`[string]` defaults to `"## %a. %b %d, %Y - %I:%M %p"` or `"## Fri. Apr 06, 2024 - 06:48 PM"`): can be any bash string such as a date format expression. It is ignored if `ADD_NEWNOTE_TIMESTAMP` is set to `"false"`.
+- `ADD_ENTRY_TIMESTAMP` (`[boolean]` defaults to `true`): Whether to add a time stamp when using `tdo entry` or `tdo e`.
+- `ADD_NEWNOTE_TIMESTAMP` (`[boolean]` defaults to `false`): Whether to add a time stamp when creating new notes with `tdo <note_title>`.
+- `FILE_NAME_AS_TITLE` (`[boolean]` defaults to `false`): Whether to add the file name as title when creating new notes with `tdo <note_title>`. If `true`, then it adds `<note_title>` as a markdown title in the first line of the new note.
+- `ENTRY_TIMESTAMP_FORMAT` (`[string]` defaults to `"## %a, %I:%M %p"` or `"## Mon, 12:00 PM"`): can be any bash string such as a date format expression. It is ignored if `ADD_ENTRY_TIMESTAMP` is set to `false`.
+- `NOTE_TIMESTAMP_FORMAT`(`[string]` defaults to `"## %a. %b %d, %Y - %I:%M %p"` or `"## Fri. Apr 06, 2024 - 06:48 PM"`): can be any bash string such as a date format expression. It is ignored if `ADD_NEWNOTE_TIMESTAMP` is set to `false`.
 
 ### Using a `tdorc` file
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,33 @@ If you use Neovim, I highly recommend using [tdo.nvim](https://github.com/2kabhi
     └── note.md
     └── todo.md
 ```
+## Configuration
+
+You can further configure `tdo` by either defining environment variables or via a `tdorc` file.
+
+### Using environment variables
+
+You can set the following (optional) environment variables:
+
+- `TIMESTAMP_ENTRY` (`["true"|"false"]` defaults to `"true"`): Whether to add a time stamp when using `tdo entry` or `tdo e`.
+- `TIMESTAMP_NEWNOTE` (`["true"|"false"]` defaults to `"false"`): Whether to add a time stamp when creating new notes with `tdo <note_title>`.
+- `FILE_NAME_AS_TITLE` (`["true"|"false"]` defaults to `"false"`): Whether to add the file name as title when creating new notes with `tdo <note_title>`. If `"true"`, then it adds `<note_title>` as a markdown title to the end of the new note.
+- `ENTRY_TIMESTAMP` (`[string]` defaults to `"## %a, %I:%M %p"`): can be any bash string such as a date format expression. It is ignored if `TIMESTAMP_ENTRY` is set to `"false"`.
+- `NOTE_TIMESTAMP`(`[string]` defaults to `"## %a. %b %d, %Y - %I:%M%p"`): can be any bash string such as a date format expression. It is ignored if `TIMESTAMP_NEWNOTE` is set to `"false"`.
+
+### Using a `tdorc` file
+
+Alternatively, it is possible to define the same variables in a `$HOME/.config/tdorc` file following bash syntax. For example:
+
+```bash
+TIMESTAMP_ENTRY=false
+TIMESTAMP_NEWNOTE=true
+FILE_NAME_AS_TITLE=true
+ENTRY_TIMESTAMP="## %I:%M %p"
+NOTE_TIMESTAMP="## Created: %a. %b %d, %Y at %I:%M%p"
+```
+
+**Note** that if any of these variables are set as environment variables, then the `tdorc` will be ignored completely. That is, it is not possible to use both environment variables configuration together with a `tdorc` configuration.
 
 ## 🏗️ What's Next
 

--- a/tdo.sh
+++ b/tdo.sh
@@ -43,7 +43,6 @@ For more information, visit https://github.com/2kabhishek/tdo
 EOF
 }
 
-# setup config variables
 config_setup() {
   source $HOME/.config/tdorc
 

--- a/tdo.sh
+++ b/tdo.sh
@@ -48,7 +48,7 @@ config_setup() {
   source $HOME/.config/tdorc
 
   add_entry_timestamp="${ADD_ENTRY_TIMESTAMP:-true}"
-  add_new_note_timestamp="${ADD_NEWNOTE_TIMESTAMP:-false}"
+  add_new_note_timestamp="${ADD_NEW_NOTE_TIMESTAMP:-false}"
   filename_as_title="${FILE_NAME_AS_TITLE:-false}"
   entry_timestamp_format="${ENTRY_TIMESTAMP_FORMAT:-"## %a, %I:%M %p"}"
   note_timestamp_format="${NOTE_TIMESTAMP_FORMAT:-"## %a. %b %d, %Y - %I:%M %p"}"

--- a/tdo.sh
+++ b/tdo.sh
@@ -43,23 +43,13 @@ For more information, visit https://github.com/2kabhishek/tdo
 EOF
 }
 
-# validate whether a variable is set to true or false, and set to default otherwise
-validate_and_set() {
-    local default_val="${2:-true}"
-    local var_value="${1:-$default_val}"
-    if [[ "$var_value" != "true" && "$var_value" != "false" ]]; then
-        var_value=$default_val
-    fi
-    echo "$var_value"
-}
-
 # setup config variables
 config_setup() {
   source $HOME/.config/tdorc
 
-  add_entry_timestamp="$(validate_and_set "${ADD_ENTRY_TIMESTAMP}" "true")"
-  add_new_note_timestamp="$(validate_and_set "${ADD_NEWNOTE_TIMESTAMP}" "false")"
-  filename_as_title="$(validate_and_set "${FILE_NAME_AS_TITLE}" "false")"
+  add_entry_timestamp="${ADD_ENTRY_TIMESTAMP:-true}"
+  add_new_note_timestamp="${ADD_NEWNOTE_TIMESTAMP:-false}"
+  filename_as_title="${FILE_NAME_AS_TITLE:-false}"
   entry_timestamp_format="${ENTRY_TIMESTAMP_FORMAT:-"## %a, %I:%M %p"}"
   note_timestamp_format="${NOTE_TIMESTAMP_FORMAT:-"## %a. %b %d, %Y - %I:%M %p"}"
 }
@@ -172,11 +162,10 @@ new_note() {
     root="$NOTES_DIR"
     note_file="$root/notes/$1.md"
     template="$root/templates/note.md"
-    [ ! -f "$note_file" ] && new_file="true" || new_file="false"
-    create_file "$note_file" "$template"
-    if [ "$new_file" = "true" ]; then
-      [ $filename_as_title = "true" ] && echo -e "# $1" >>"$note_file"
-      [ $add_new_note_timestamp = "true" ] && add_timestamp "$note_file" "$note_timestamp_format"
+    if [ ! -f "$note_file" ]; then
+      create_file "$note_file" "$template"
+      $filename_as_title && echo -e "# $1" >>"$note_file"
+      $add_new_note_timestamp && add_timestamp "$note_file" "$note_timestamp_format"
     fi
     write_file "$note_file" "$root"
 }
@@ -199,7 +188,7 @@ new_entry() {
     entry_file="$root/entries/$(generate_file_path "$1")"
     template="$root/templates/entry.md"
     create_file "$entry_file" "$template"
-    [ $add_entry_timestamp = "true" ] && add_timestamp "$entry_file" "$entry_timestamp_format"
+    $add_entry_timestamp && add_timestamp "$entry_file" "$entry_timestamp_format"
     write_file "$entry_file" "$root"
 }
 

--- a/tdo.sh
+++ b/tdo.sh
@@ -133,9 +133,9 @@ create_file() {
 
 add_timestamp() {
     file_path="$1"
-    time_format="${2:-%a, %I:%M %p}"
+    time_format="${2:-## %a, %I:%M %p}"
     timestamp=$(date +"$time_format")
-    echo -e "\n## $timestamp\n" >>"$file_path"
+    echo -e "\n$timestamp\n" >>"$file_path"
 }
 
 write_file() {
@@ -192,7 +192,7 @@ new_note() {
     create_file "$note_file" "$template"
     if [ "$new_file" = "true" ]; then
       [ "$(validate_and_set "${FILE_NAME_AS_TITLE}" false)" = "true" ] && echo -e "# $1" >>"$note_file"
-      [ "$(validate_and_set "${TIMESTAMP_NEWNOTE}" false)" = "true" ] && add_timestamp "$note_file" "${NOTE_TIMESTAMP:-}"
+      [ "$(validate_and_set "${TIMESTAMP_NEWNOTE}" false)" = "true" ] && add_timestamp "$note_file" "${NOTE_TIMESTAMP:-"## %a. %b %d, %Y - %I:%M%p"}"
     fi
     write_file "$note_file" "$root"
 }


### PR DESCRIPTION
## What

What does this pull request accomplish?

- [x] Add env variables for several config options.
- [x] Add tdorc config file option instead of using env variables.

**Note** that only one option can be used by the user. If one or more env variables are set, then the tdorc file is ignored.

## How

What code changes were made to accomplish it?

- Add a `config_setup` function to setup the config variables.
- Modify the `new_note` and `new_entry` functions to allow for additional config options.

## Why

- [x] Address issue #9.

## Additional Notes

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
